### PR TITLE
Fix collections import

### DIFF
--- a/pcaspy/driver.py
+++ b/pcaspy/driver.py
@@ -1,11 +1,14 @@
 from . import cas
 from .alarm import Severity, Alarm
-import collections.abc
 import operator
 import threading
 import time
 import sys
 import logging
+if sys.version_info[0] == 2 or (sys.version_info[0] == 3 and sys.version_info[1] < 3):
+    import collections
+else:
+    import collections.abc as collections
 if sys.hexversion >= 0x02070000:
     from logging import NullHandler
 else:
@@ -479,7 +482,7 @@ class PVInfo(object):
         :param limit: numeric scalar
         :param op: comparision operators, le, ge etc
         """
-        if isinstance(value, collections.abc.Iterable):
+        if isinstance(value, collections.Iterable):
             return any(op(v, limit) for v in value)
         else:
             return op(value, limit)

--- a/pcaspy/driver.py
+++ b/pcaspy/driver.py
@@ -1,6 +1,6 @@
 from . import cas
 from .alarm import Severity, Alarm
-import collections
+import collections.abc
 import operator
 import threading
 import time
@@ -479,7 +479,7 @@ class PVInfo(object):
         :param limit: numeric scalar
         :param op: comparision operators, le, ge etc
         """
-        if isinstance(value, collections.Iterable):
+        if isinstance(value, collections.abc.Iterable):
             return any(op(v, limit) for v in value)
         else:
             return op(value, limit)

--- a/pcaspy/gdd.i
+++ b/pcaspy/gdd.i
@@ -16,8 +16,11 @@ import sys
 if sys.version_info[0] > 2:
     str2char = lambda x: bytes(str(x),'utf8')
     numerics = (bool, int, float)
-    import collections.abc
-    is_sequence = lambda x: isinstance(x, collections.abc.Sequence)
+    if sys.version_info[0] == 3 and sys.version_info[1] < 3:
+        import collections
+    else:
+        import collections.abc as collections
+    is_sequence = lambda x: isinstance(x, collections.Sequence)
 else: 
     str2char = str
     numerics = (bool, int, float, long)


### PR DESCRIPTION
Hi, guys!

This PR fixes the `collections` import (that will be deprecated in python 3.10, and try to keep compatibility of pcaspy with python < 3.3.